### PR TITLE
camera: Fix high battery drain after using flashlight

### DIFF
--- a/services/camera/libcameraservice/CameraFlashlight.cpp
+++ b/services/camera/libcameraservice/CameraFlashlight.cpp
@@ -916,7 +916,7 @@ status_t CameraHardwareInterfaceFlashControl::disconnectCameraDevice() {
     }
     mDevice->setPreviewWindow(NULL);
     mDevice->release();
-    mDevice = NULL;
+    mDevice.clear();
 
     return OK;
 }


### PR DESCRIPTION
After turning off the flashlight via the tile, the camera is kept open,
preventing the device from entering deep sleep (and destroying battery
life).

Properly close the camera after turning off the flashlight in order to fix
the high battery drain.

Change-Id: Iea643a272817db802f2e78c1a223fe817d98f813